### PR TITLE
Support for Xaml

### DIFF
--- a/QRCoder/QRCoder.NET40.csproj
+++ b/QRCoder/QRCoder.NET40.csproj
@@ -33,6 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -44,6 +46,7 @@
       <HintPath>UnityEngine.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractQRCode.cs" />
@@ -59,6 +62,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SvgQRCode.cs" />
     <Compile Include="UnityQRCode.cs" />
+    <Compile Include="XamlQRCode.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -32,6 +32,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -43,6 +45,7 @@
       <HintPath>UnityEngine.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AbstractQRCode.cs" />
@@ -59,6 +62,7 @@
     <Compile Include="Framework4.0Methods\String4Methods.cs" />
     <Compile Include="SvgQRCode.cs" />
     <Compile Include="UnityQRCode.cs" />
+    <Compile Include="XamlQRCode.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/QRCoder/XamlQRCode.cs
+++ b/QRCoder/XamlQRCode.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Media;
+
+namespace QRCoder
+{
+    public class XamlQRCode : AbstractQRCode<DrawingImage>, IDisposable
+    {
+        public XamlQRCode(QRCodeData data) : base(data) { }
+
+        public override DrawingImage GetGraphic(int pixelsPerModule)
+        {
+            return this.GetGraphic(pixelsPerModule, true);
+        }
+
+        public DrawingImage GetGraphic(int pixelsPerModule, bool drawQuietZones)
+        {
+            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var viewBox = new Size(pixelsPerModule * drawableModulesCount, pixelsPerModule * drawableModulesCount);
+            return this.GetGraphic(viewBox, new SolidColorBrush(Colors.Black), new SolidColorBrush(Colors.White), drawQuietZones);
+        }
+
+        public DrawingImage GetGraphic(Size viewBox, bool drawQuietZones = true)
+        {
+            return this.GetGraphic(viewBox, new SolidColorBrush(Colors.Black), new SolidColorBrush(Colors.White), drawQuietZones);
+        }
+
+        public DrawingImage GetGraphic(int pixelsPerModule, string darkColorHex, string lightColorHex, bool drawQuietZones = true)
+        {
+            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var viewBox = new Size(pixelsPerModule * drawableModulesCount, pixelsPerModule * drawableModulesCount);
+            return this.GetGraphic(viewBox, new SolidColorBrush((Color)ColorConverter.ConvertFromString(darkColorHex)), new SolidColorBrush((Color)ColorConverter.ConvertFromString(lightColorHex)), drawQuietZones);
+        }
+
+        public DrawingImage GetGraphic(Size viewBox, Brush darkBrush, Brush lightBrush, bool drawQuietZones = true)
+        {
+            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var qrSize = Math.Min(viewBox.Width, viewBox.Height);
+            var unitsPerModule = qrSize / drawableModulesCount;
+            var offsetModules = drawQuietZones ? 0 : 4;
+
+            DrawingGroup drawing = new DrawingGroup();
+            drawing.Children.Add(new GeometryDrawing(lightBrush, null, new RectangleGeometry(new Rect(new Point(0, 0), new Size(qrSize, qrSize)))));
+
+            var group = new GeometryGroup();
+            int xi = 0, yi = 0;
+            for (var x = 0d; x < qrSize; x = x + unitsPerModule)
+            {
+                yi = 0;
+                for (var y = 0d; y < qrSize; y = y + unitsPerModule)
+                {
+                    if (this.QrCodeData.ModuleMatrix[yi + offsetModules][xi + offsetModules])
+                    {
+                        group.Children.Add(new RectangleGeometry(new Rect(x, y, unitsPerModule, unitsPerModule)));
+                    }
+                    yi++;
+                }
+                xi++;
+            }
+            drawing.Children.Add(new GeometryDrawing(darkBrush, null, group));
+
+            return new DrawingImage(drawing);
+        }
+
+        public void Dispose()
+        {
+            this.QrCodeData = null;
+        }
+    }
+}

--- a/QRCoderConsole/Program.cs
+++ b/QRCoderConsole/Program.cs
@@ -6,6 +6,7 @@ using NDesk.Options;
 using System.Reflection;
 using QRCoder;
 using System.Text;
+using System.Windows.Markup;
 
 namespace QRCoderConsole
 {
@@ -34,7 +35,7 @@ namespace QRCoderConsole
                     value => eccLevel = setter.GetECCLevel(value)
                 },
                 {   "f|output-format=",
-                    "Image format for outputfile. Possible values: png, jpg, gif, bmp, tiff, svg (default: png)",
+                    "Image format for outputfile. Possible values: png, jpg, gif, bmp, tiff, svg, xaml (default: png)",
                     value => { Enum.TryParse(value, true, out imageFormat); }
                 },
                 {
@@ -156,6 +157,17 @@ namespace QRCoderConsole
                             using (var code = new SvgQRCode(data))
                             {
                                 var test = code.GetGraphic(pixelsPerModule, foreground, background, true);
+                                using (var f = File.CreateText(outputFileName))
+                                {
+                                    f.Write(test);
+                                    f.Flush();
+                                }
+                            }
+                            break;
+                        case SupportedImageFormat.Xaml:
+                            using (var code = new XamlQRCode(data))
+                            {
+                                var test = XamlWriter.Save(code.GetGraphic(pixelsPerModule, foreground, background, true));
                                 using (var f = File.CreateText(outputFileName))
                                 {
                                     f.Write(test);

--- a/QRCoderConsole/QRCoderConsole.csproj
+++ b/QRCoderConsole/QRCoderConsole.csproj
@@ -29,11 +29,14 @@
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="NDesk.Options">
       <HintPath>..\packages\NDesk.Options.0.2.1\lib\NDesk.Options.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />

--- a/QRCoderConsole/SupportedImageFormat.cs
+++ b/QRCoderConsole/SupportedImageFormat.cs
@@ -14,5 +14,6 @@ namespace QRCoderConsole
         Bmp,
         Tiff,
         Svg,
+        Xaml,
     }
 }


### PR DESCRIPTION
This PR adds support for XAML to make QRCoder directly usable in WPF projects.

Furthermore, it extends QRCoderConsole utility with the ability to output XAML files.

The code has been ported from https://github.com/Amebis/eduVPN/blob/master/eduVPN.Client/QRCoder/XamlQRCode.cs under originating author permission.

Example use-case:
```C#
public class TOTPQRConverter : IMultiValueConverter
{
    public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
    {
        try
        {
            var secret = values[0] as string;
            var hostname = values[1] as string;
            var displayname = values[2] as string;
            var otp_uri = string.Format("otpauth://totp/{1}?secret={0}&issuer={2}",
                secret,
                hostname,
                HttpUtility.UrlEncode(displayname));

            var qr_generator = new QRCodeGenerator();
            var qr_code_data = qr_generator.CreateQrCode(otp_uri, QRCodeGenerator.ECCLevel.Q);
            var qr_code = new XamlQRCode(qr_code_data);
            return qr_code.GetGraphic(1, false);
        }
        catch { }

        // Fallback to blank image.
        return new Uri("pack://application:,,,/Resources/Blank.png");
    }

    public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
    {
        throw new NotImplementedException();
    }
}
```