### PR TITLE
CreateAntilogTable doing unnecessary Pow calculations

### DIFF
--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1257,16 +1257,22 @@ namespace QRCoder
 
             for (var i = 0; i < 256; i++)
             {
-                var gfItem = (int)Math.Pow(2, i);
+                int gfItem;
 
                 if (i > 7)
                 {
                     gfItem = this.galoisField[i - 1].IntegerValue * 2;
                 }
+                else
+                {
+                    gfItem = (int)Math.Pow(2, i);
+                }
+
                 if (gfItem > 255)
                 {
                     gfItem = gfItem ^ 285;
                 }
+
                 this.galoisField.Add(new Antilog(i, gfItem));
             }
         }


### PR DESCRIPTION
This change doesn't modify the galoisField values as the previous version worked just fine in regard to the data generated. It was just doing an unnecessary Pow() calculation that was meaningless after the value of "i" was greater than 7.

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [ ] Bug 1
* [ ] Bug 2
* [ ] Feature 1
* [ ] Feature 2
* [ ] Breaking changes

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

Demonstrate that your code is solid. If possible add a short test case/test steps.

**Closing issues**

<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
