### PR TITLE
fixed issue #145 with OutOfRange Exception generating Xaml QR Code images

### DIFF
--- a/QRCoder/XamlQRCode.cs
+++ b/QRCoder/XamlQRCode.cs
@@ -48,19 +48,19 @@ namespace QRCoder
             drawing.Children.Add(new GeometryDrawing(lightBrush, null, new RectangleGeometry(new Rect(new Point(0, 0), new Size(qrSize, qrSize)))));
 
             var group = new GeometryGroup();
-            int xi = 0, yi = 0;
-            for (var x = 0d; x < qrSize; x = x + unitsPerModule)
+            double x = 0d, y = 0d;
+            for (int xi = offsetModules; xi < drawableModulesCount; xi++)
             {
-                yi = 0;
-                for (var y = 0d; y < qrSize; y = y + unitsPerModule)
+                y = 0d;
+                for (int yi = offsetModules; yi < drawableModulesCount; yi++)
                 {
-                    if (this.QrCodeData.ModuleMatrix[yi + offsetModules][xi + offsetModules])
+                    if (this.QrCodeData.ModuleMatrix[yi][xi])
                     {
                         group.Children.Add(new RectangleGeometry(new Rect(x, y, unitsPerModule, unitsPerModule)));
                     }
-                    yi++;
+                    y += unitsPerModule;
                 }
-                xi++;
+                x += unitsPerModule;
             }
             drawing.Children.Add(new GeometryDrawing(darkBrush, null, group));
 


### PR DESCRIPTION
**Summary**
Refactors the GetGraphic loop for Xaml QR Code to avoid a System.OutOfRange Exception, especially when dealing with `unitsPerModule` values that are doubles with repeating decimal places.

An example of this found in the original bug issue was that the size limit was `200`, but the unlimited precision of the double `yi` allowed it to reach a value of `199.99999992` (rough estimate) and so the loop did not terminate as expected.

This refactor instead loops on the data of the QR code (always an `int`) while adding to the pixel values, a reverse of the original structure. This avoids the System.OutOfRange exception when accessing the QR code data.


This PR fixes the following **bugs**:

* [x]  #145

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?

Fixes OutOfRangeException encountered in #145

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

Demonstrate that your code is solid. If possible add a short test case/test steps.

Tested with repeatable bug code found in #145.
 Additionally, compare the image results from the QRCode library (base case) and the XamlQRCode library (using fix contained in this PR). Both were generated with the original bugged string "Something that ends up with a size 41 QRCode" : [imgur link](https://imgur.com/a/YUyZAuG)

**Closing issues**

<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
`closes #145`
