### PR TITLE
Add contact/phone number to WhatsApp Payload

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -326,7 +326,18 @@ namespace QRCoder
 
         public class WhatsAppMessage : Payload
         {
-            private readonly string message;
+            private readonly string number, message;
+
+            /// <summary>
+            /// Let's you compose a WhatApp message and send it the receiver number.
+            /// </summary>
+            /// <param name="number">Receiver phone number</param>
+            /// <param name="message">The message</param>
+            public WhatsAppMessage(string number, string message)
+            {
+                this.number = number;
+                this.message = message;
+            }
 
             /// <summary>
             /// Let's you compose a WhatApp message. When scanned the user is asked to choose a contact who will receive the message.
@@ -334,12 +345,13 @@ namespace QRCoder
             /// <param name="message">The message</param>
             public WhatsAppMessage(string message)
             {
+                this.number = string.Empty;
                 this.message = message;
             }
 
             public override string ToString()
             {
-                return ($"whatsapp://send?text={Uri.EscapeDataString(message)}");
+                return ($"whatsapp://send?phone={this.number}&text={Uri.EscapeDataString(message)}");
             }
         }
 

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -2567,12 +2567,25 @@ namespace QRCoderTests
         [Category("PayloadGenerator/WhatsAppMessage")]
         public void whatsapp_generator_can_generate_payload_simple()
         {
+            var number = "01601234567";
+            var msg = "This is a sample message with Umlauts: Ä,ö, ü and ß.";
+            var generator = new PayloadGenerator.WhatsAppMessage(number, msg);
+
+            generator
+                .ToString()
+                .ShouldBe("whatsapp://send?phone=01601234567&text=This%20is%20a%20sample%20message%20with%20Umlauts%3A%20%C3%84%2C%C3%B6%2C%20%C3%BC%20and%20%C3%9F.");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/WhatsAppMessage")]
+        public void whatsapp_should_add_unused_params()
+        {
             var msg = "This is a sample message with Umlauts: Ä,ö, ü and ß.";
             var generator = new PayloadGenerator.WhatsAppMessage(msg);
 
             generator
                 .ToString()
-                .ShouldBe("whatsapp://send?text=This%20is%20a%20sample%20message%20with%20Umlauts%3A%20%C3%84%2C%C3%B6%2C%20%C3%BC%20and%20%C3%9F.");
+                .ShouldBe("whatsapp://send?phone=&text=This%20is%20a%20sample%20message%20with%20Umlauts%3A%20%C3%84%2C%C3%B6%2C%20%C3%BC%20and%20%C3%9F.");
         }
 
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summarize your pull request in a couple of words -->
This PR gives creates a new overload to the WhatsApp payload by giving the user the ability to add contact/phone number to WhatsApp Payload. This is can be achieved since WhatsApp is allowing passing the contact/phone number in the following format
`$"whatsapp://send/?phone={number}&text={message}"`

This PR fixes/implements the following **features**:

* [X] Add contact/phonenumber to WhatsApp Payload

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?
Just adding gives the user a new feature to send the WhatsApp message directly to the desired contact.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

Demonstrate that your code is solid. If possible add a short test case/test steps.
UnitTests:

- [ whatsapp_generator_can_generate_payload_simple] still working.

- [ whatsapp_should_add_unused_params] new unit test method to test if the phone number is missing. 

**Closing issues**

<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
