### PR TITLE
The website field is not added to the vcard if it was of type other than MeCard

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -551,7 +551,7 @@ namespace QRCoder
                     
                     if (birthday != null)
                         payload += $"BDAY:{((DateTime)birthday).ToString("yyyyMMdd")}\r\n";
-                    if (!string.IsNullOrEmpty(phone))
+                    if (!string.IsNullOrEmpty(website))
                         payload += $"URL:{website}\r\n";
                     if (!string.IsNullOrEmpty(email))
                         payload += $"EMAIL:{email}\r\n";


### PR DESCRIPTION
Root cause: Null was checked on phone field to add the website field to the vcard

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [ ] #170 

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?
The website field was never added to the vcard if it was of type other than MeCard and if the phone field was null.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

Existing test cases should pass.

**Closing issues**

<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
Changed the null checking to website field for adding the website data to the vcard.