### PR TITLE
Add XamlQRCode.GetUnitsPerModule() method

### DIFF
--- a/QRCoder/XamlQRCode.cs
+++ b/QRCoder/XamlQRCode.cs
@@ -20,7 +20,7 @@ namespace QRCoder
 
         public DrawingImage GetGraphic(int pixelsPerModule, bool drawQuietZones)
         {
-            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var drawableModulesCount = GetDrawableModulesCount(drawQuietZones);
             var viewBox = new Size(pixelsPerModule * drawableModulesCount, pixelsPerModule * drawableModulesCount);
             return this.GetGraphic(viewBox, new SolidColorBrush(Colors.Black), new SolidColorBrush(Colors.White), drawQuietZones);
         }
@@ -32,14 +32,14 @@ namespace QRCoder
 
         public DrawingImage GetGraphic(int pixelsPerModule, string darkColorHex, string lightColorHex, bool drawQuietZones = true)
         {
-            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var drawableModulesCount = GetDrawableModulesCount(drawQuietZones);
             var viewBox = new Size(pixelsPerModule * drawableModulesCount, pixelsPerModule * drawableModulesCount);
             return this.GetGraphic(viewBox, new SolidColorBrush((Color)ColorConverter.ConvertFromString(darkColorHex)), new SolidColorBrush((Color)ColorConverter.ConvertFromString(lightColorHex)), drawQuietZones);
         }
 
         public DrawingImage GetGraphic(Size viewBox, Brush darkBrush, Brush lightBrush, bool drawQuietZones = true)
         {
-            var drawableModulesCount = this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+            var drawableModulesCount = GetDrawableModulesCount(drawQuietZones);
             var qrSize = Math.Min(viewBox.Width, viewBox.Height);
             var unitsPerModule = qrSize / drawableModulesCount;
             var offsetModules = drawQuietZones ? 0 : 4;
@@ -65,6 +65,18 @@ namespace QRCoder
             drawing.Children.Add(new GeometryDrawing(darkBrush, null, group));
 
             return new DrawingImage(drawing);
+        }
+
+        private int GetDrawableModulesCount(bool drawQuietZones = true)
+        {
+            return this.QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : 8);
+        }
+
+        public double GetUnitsPerModule(Size viewBox, bool drawQuietZones = true)
+        {
+            var drawableModulesCount = GetDrawableModulesCount(drawQuietZones);
+            var qrSize = Math.Min(viewBox.Width, viewBox.Height);
+            return qrSize / drawableModulesCount;
         }
     }
 }


### PR DESCRIPTION
**Summary**

This is a helper method allowing client to obtain an exact measure of module size without a need to repeat the calculation by itself.

When the client wants to draw a border around QR code or some other adornments which need to use the same size and/or spacing as the module size this commit simplifies its calculation.

* [ ] Introduces XamlQRCode.GetUnitsPerModule() helper method