### PR TITLE
Feature/ Added a flag to prevent/force Data trimming while creating QRCode while creating QRCode with requested version

### DIFF
--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1,9 +1,8 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Collections;
-using System.Reflection;
 
 namespace QRCoder
 {
@@ -68,12 +67,13 @@ namespace QRCoder
         /// <param name="forceUtf8">Shall the generator be forced to work in UTF-8 mode?</param>
         /// <param name="utf8BOM">Should the byte-order-mark be used?</param>
         /// <param name="eciMode">Which ECI mode shall be used?</param>
-        /// <param name="requestedVersion">Set fixed QR code target version.</param>
+        /// <param name="requestedVersion">Set fixed QR code target version. Will be overridded to accomodate data if trimDataToEnforceRequestedVersion is set to false</param>
+        /// <param name="trimDataToEnforceRequestedVersion">Allow data to be trimmed to keep output version same as requested version.</param>
         /// <exception cref="QRCoder.Exceptions.DataTooLongException">Thrown when the payload is too big to be encoded in a QR code.</exception>
         /// <returns>Returns the raw QR code data which can be used for rendering.</returns>
-        public QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1)
+        public QRCodeData CreateQrCode(string plainText, ECCLevel eccLevel, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1, bool trimDataToEnforceRequestedVersion = true)
         {
-            return GenerateQrCode(plainText, eccLevel, forceUtf8, utf8BOM, eciMode, requestedVersion);
+            return GenerateQrCode(plainText, eccLevel, forceUtf8, utf8BOM, eciMode, requestedVersion, trimDataToEnforceRequestedVersion);
         }
 
         /// <summary>
@@ -120,19 +120,16 @@ namespace QRCoder
         /// <param name="forceUtf8">Shall the generator be forced to work in UTF-8 mode?</param>
         /// <param name="utf8BOM">Should the byte-order-mark be used?</param>
         /// <param name="eciMode">Which ECI mode shall be used?</param>
-        /// <param name="requestedVersion">Set fixed QR code target version.</param>
+        /// <param name="requestedVersion">Set fixed QR code target version. Will be overridded to accomodate data if trimDataToEnforceRequestedVersion is set to false</param>
+        /// <param name="trimDataToEnforceRequestedVersion">Allow data to be trimmed to keep output version same as requested version.</param>
         /// <exception cref="QRCoder.Exceptions.DataTooLongException">Thrown when the payload is too big to be encoded in a QR code.</exception>
         /// <returns>Returns the raw QR code data which can be used for rendering.</returns>
-        public static QRCodeData GenerateQrCode(string plainText, ECCLevel eccLevel, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1)
+        public static QRCodeData GenerateQrCode(string plainText, ECCLevel eccLevel, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1, bool trimDataToEnforceRequestedVersion = true)
         {
             EncodingMode encoding = GetEncodingFromPlaintext(plainText, forceUtf8);
             var codedText = PlainTextToBinary(plainText, encoding, eciMode, utf8BOM, forceUtf8);
             var dataInputLength = GetDataLength(encoding, plainText, codedText, forceUtf8);
-            int version = requestedVersion;
-            if (version == -1)
-            {
-                version = GetVersion(dataInputLength, encoding, eccLevel);
-            }
+            int version = (trimDataToEnforceRequestedVersion && requestedVersion >= 1) ? requestedVersion : Math.Max(requestedVersion, GetVersion(dataInputLength, encoding, eccLevel));
 
             string modeIndicator = String.Empty;
             if (eciMode != EciMode.Default)
@@ -402,11 +399,11 @@ namespace QRCoder
                 var size = qrCode.ModuleMatrix.Count;
 
 
-                #if NET40
-                    var methods = typeof (MaskPattern).GetMethods();
-                #else
-                    var methods = typeof (MaskPattern).GetTypeInfo().DeclaredMethods;
-                #endif
+#if NET40
+                var methods = typeof(MaskPattern).GetMethods();
+#else
+                    var methods = typeof(MaskPattern).GetTypeInfo().DeclaredMethods;
+#endif
 
                 foreach (var pattern in methods)
                 {
@@ -422,7 +419,7 @@ namespace QRCoder
 
                         }
 
-                        var formatStr = GetFormatString(eccLevel, Convert.ToInt32((pattern.Name.Substring(7, 1)))-1);
+                        var formatStr = GetFormatString(eccLevel, Convert.ToInt32((pattern.Name.Substring(7, 1))) - 1);
                         ModulePlacer.PlaceFormat(ref qrTemp, formatStr);
                         if (version >= 7)
                         {
@@ -453,11 +450,11 @@ namespace QRCoder
 
 
 
-                #if NET40
-                    var patterMethod = typeof(MaskPattern).GetMethods().First(x => x.Name == patternName);
-                #else
+#if NET40
+                var patterMethod = typeof(MaskPattern).GetMethods().First(x => x.Name == patternName);
+#else
                     var patterMethod = typeof(MaskPattern).GetTypeInfo().GetDeclaredMethod(patternName);
-                #endif
+#endif
 
 
                 for (var x = 0; x < size; x++)
@@ -479,7 +476,7 @@ namespace QRCoder
                 var size = qrCode.ModuleMatrix.Count;
                 var up = true;
                 var datawords = new Queue<bool>();
-                for (int i = 0; i< data.Length; i++)
+                for (int i = 0; i < data.Length; i++)
                 {
                     datawords.Enqueue(data[i] != '0');
                 }
@@ -795,9 +792,9 @@ namespace QRCoder
                                 blackModules++;
 
                     var percent = (blackModules / (qrCode.ModuleMatrix.Count * qrCode.ModuleMatrix.Count)) * 100;
-                    var prevMultipleOf5 = Math.Abs((int) Math.Floor(percent/5)*5 - 50)/5;
-                    var nextMultipleOf5 = Math.Abs((int)Math.Floor(percent / 5) * 5 -45)/5;
-                    score4 = Math.Min(prevMultipleOf5, nextMultipleOf5)*10;
+                    var prevMultipleOf5 = Math.Abs((int)Math.Floor(percent / 5) * 5 - 50) / 5;
+                    var nextMultipleOf5 = Math.Abs((int)Math.Floor(percent / 5) * 5 - 45) / 5;
+                    score4 = Math.Min(prevMultipleOf5, nextMultipleOf5) * 10;
 
                     return score1 + score2 + score3 + score4;
                 }
@@ -817,7 +814,7 @@ namespace QRCoder
 
             for (var i = 0; i < generatorPolynom.PolyItems.Count; i++)
                 generatorPolynom.PolyItems[i] = new PolynomItem(generatorPolynom.PolyItems[i].Coefficient,
-                    generatorPolynom.PolyItems[i].Exponent + (messagePolynom.PolyItems.Count-1));
+                    generatorPolynom.PolyItems[i].Exponent + (messagePolynom.PolyItems.Count - 1));
 
             var leadTermSource = messagePolynom;
             for (var i = 0; (leadTermSource.PolyItems.Count > 0 && leadTermSource.PolyItems[leadTermSource.PolyItems.Count - 1].Exponent > 0); i++)
@@ -1008,13 +1005,13 @@ namespace QRCoder
         {
             var bytes = Encoding.GetEncoding("ISO-8859-1").GetBytes(input);
             //var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes);
-            var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes,0,bytes.Length);
+            var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes, 0, bytes.Length);
             return String.Equals(input, result);
         }
 
         private static string PlainTextToBinary(string plainText, EncodingMode encMode, EciMode eciMode, bool utf8BOM, bool forceUtf8)
         {
-            switch(encMode)
+            switch (encMode)
             {
                 case EncodingMode.Alphanumeric:
                     return PlainTextToBinaryAlphanumeric(plainText);
@@ -1075,7 +1072,7 @@ namespace QRCoder
         {
             var codeText = string.Empty;
             byte[] _bytes = Encoding.GetEncoding("ascii").GetBytes(plainText);
-            foreach(byte _byte in _bytes)
+            foreach (byte _byte in _bytes)
             {
                 codeText += DecToBin(_byte, 8);
             }
@@ -1104,7 +1101,7 @@ namespace QRCoder
                 codeBytes = Encoding.GetEncoding("ISO-8859-1").GetBytes(plainText);
             else
             {
-                switch(eciMode)
+                switch (eciMode)
                 {
                     case EciMode.Iso8859_1:
                         codeBytes = Encoding.GetEncoding("ISO-8859-1").GetBytes(ConvertToIso8859(plainText, "ISO-8859-1"));


### PR DESCRIPTION
**Summary**

Added a flag to prevent/force Data trimming while creating QRCode with requested version

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [x] When a Requested Version is put in Qr code Trims Data for the version, It should Auto Upgrade or User Should have an option to choose to trim or AutoUpgrade Version to keep Data in QR Code.

>What problem does it Solve
There is no option to set minimum version and so user may have to calculate Version himself. To prevent this, an option to send requested version and a flag to override/Enforce the Requested version to prevent data from getting trimmed off has been added.

**Test plan**
No functional changes. All existing tests pass. All old functioning have been ensured during the changes. Issue has been handled by adding another optional Boolean flag