### PR TITLE
Fix validating country code in Contact

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -984,8 +984,8 @@ namespace QRCoder
                         this.zipCode = this.city = string.Empty;
                     }
 
-#if NET40
-                    if (!CultureInfo.GetCultures(CultureTypes.SpecificCultures).Where(x => new RegionInfo(x.LCID).TwoLetterISORegionName.ToUpper() == country.ToUpper()).Any())
+#if !NETSTANDARD1_1
+                    if (!CultureInfo.GetCultures(CultureTypes.SpecificCultures).Any(x => string.Equals(new RegionInfo(x.LCID).TwoLetterISORegionName, country, StringComparison.OrdinalIgnoreCase)))
                         throw new SwissQrCodeContactException("Country must be a valid \"two letter\" country code as defined by  ISO 3166-1, but it isn't.");
 #else
                     try { var cultureCheck = new CultureInfo(country.ToUpper()); }
@@ -2286,7 +2286,7 @@ namespace QRCoder
             Encoding utf8 = Encoding.UTF8;
             byte[] utfBytes = utf8.GetBytes(message);
             byte[] isoBytes = Encoding.Convert(utf8, iso, utfBytes);
-#if NET40
+#if !NETSTANDARD1_1
             return iso.GetString(isoBytes);
 #else
                 return iso.GetString(isoBytes,0, isoBytes.Length);


### PR DESCRIPTION
`CultureInfo.GetCultures` is only unavailable in `NETSTANDARD1_1`

Instead of comparing two uppercased string, we can avoid the allocations be doing an case-insensitive comparison of the original strings.

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.


**Summary**

<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [x] Bug: Fix checking country code 
* [x] Feature: Improve case-insensitive string comparison by avoid extra allocations.

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan**

Demonstrate that your code is solid. If possible add a short test case/test steps.

**Closing issues**

<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #
