### PR TITLE
Add new payload generators for Bitcoin-Like cryptocurrencies

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -592,7 +592,8 @@ namespace QRCoder
 
         public class BitcoinLikeCryptoCurrencyAddress : Payload
         {
-            private readonly string currencyName, address, label, message;
+            private readonly BitcoinLikeCryptoCurrencyType currencyType;
+            private readonly string address, label, message;
             private readonly double? amount;
 
             /// <summary>
@@ -603,9 +604,9 @@ namespace QRCoder
             /// <param name="amount">Amount of coins to transfer</param>
             /// <param name="label">Reference label</param>
             /// <param name="message">Referece text aka message</param>
-            public BitcoinLikeCryptoCurrencyAddress(string currencyName, string address, double? amount, string label = null, string message = null)
+            public BitcoinLikeCryptoCurrencyAddress(BitcoinLikeCryptoCurrencyType currencyType, string address, double? amount, string label = null, string message = null)
             {
-                this.currencyName = currencyName;
+                this.currencyType = currencyType;
                 this.address = address;
 
                 if (!string.IsNullOrEmpty(label))
@@ -639,26 +640,33 @@ namespace QRCoder
                         .ToArray());
                 }
 
-                return $"{currencyName}:{address}{query}";
+                return $"{Enum.GetName(typeof(BitcoinLikeCryptoCurrencyType), currencyType).ToLower()}:{address}{query}";
+            }
+
+            public enum BitcoinLikeCryptoCurrencyType
+            {
+                Bitcoin,
+                BitcoinCash,
+                Litecoin
             }
         }
 
         public class BitcoinAddress : BitcoinLikeCryptoCurrencyAddress
         {
             public BitcoinAddress(string address, double? amount, string label = null, string message = null)
-                : base("bitcoin", address, amount, label, message) { }
+                : base(BitcoinLikeCryptoCurrencyType.Bitcoin, address, amount, label, message) { }
         }
 
         public class BitcoinCashAddress : BitcoinLikeCryptoCurrencyAddress
         {
             public BitcoinCashAddress(string address, double? amount, string label = null, string message = null)
-                : base("bitcoincash", address, amount, label, message) { }
+                : base(BitcoinLikeCryptoCurrencyType.BitcoinCash, address, amount, label, message) { }
         }
 
         public class LitecoinAddress : BitcoinLikeCryptoCurrencyAddress
         {
             public LitecoinAddress(string address, double? amount, string label = null, string message = null)
-                : base("litecoin", address, amount, label, message) { }
+                : base(BitcoinLikeCryptoCurrencyType.Litecoin, address, amount, label, message) { }
         }
 
         public class SwissQrCode : Payload

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -649,6 +649,12 @@ namespace QRCoder
                 : base("bitcoin", address, amount, label, message) { }
         }
 
+        public class BitcoinCashAddress : BitcoinLikeCryptoCurrencyAddress
+        {
+            public BitcoinCashAddress(string address, double? amount, string label = null, string message = null)
+                : base("bitcoincash", address, amount, label, message) { }
+        }
+
         public class LitecoinAddress : BitcoinLikeCryptoCurrencyAddress
         {
             public LitecoinAddress(string address, double? amount, string label = null, string message = null)

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -590,20 +590,22 @@ namespace QRCoder
             }
         }
 
-        public class BitcoinAddress : Payload
+        public class BitcoinLikeCryptoCurrencyAddress : Payload
         {
-            private readonly string address, label, message;
+            private readonly string currencyName, address, label, message;
             private readonly double? amount;
 
             /// <summary>
-            /// Generates a Bitcoin payment payload. QR Codes with this payload can open a Bitcoin payment app.
+            /// Generates a Bitcoin like cryptocurrency payment payload. QR Codes with this payload can open a payment app.
             /// </summary>
-            /// <param name="address">Bitcoin address of the payment receiver</param>
-            /// <param name="amount">Amount of Bitcoins to transfer</param>
+            /// <param name="currencyName">Bitcoin like cryptocurrency address of the payment receiver</param>
+            /// <param name="address">Bitcoin like cryptocurrency address of the payment receiver</param>
+            /// <param name="amount">Amount of coins to transfer</param>
             /// <param name="label">Reference label</param>
             /// <param name="message">Referece text aka message</param>
-            public BitcoinAddress(string address, double? amount, string label = null, string message = null)
+            public BitcoinLikeCryptoCurrencyAddress(string currencyName, string address, double? amount, string label = null, string message = null)
             {
+                this.currencyName = currencyName;
                 this.address = address;
 
                 if (!string.IsNullOrEmpty(label))
@@ -637,8 +639,20 @@ namespace QRCoder
                         .ToArray());
                 }
 
-                return $"bitcoin:{address}{query}";
+                return $"{currencyName}:{address}{query}";
             }
+        }
+
+        public class BitcoinAddress : BitcoinLikeCryptoCurrencyAddress
+        {
+            public BitcoinAddress(string address, double? amount, string label = null, string message = null)
+                : base("bitcoin", address, amount, label, message) { }
+        }
+
+        public class LitecoinAddress : BitcoinLikeCryptoCurrencyAddress
+        {
+            public LitecoinAddress(string address, double? amount, string label = null, string message = null)
+                : base("litecoin", address, amount, label, message) { }
         }
 
         public class SwissQrCode : Payload

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -199,6 +199,97 @@ namespace QRCoderTests
         }
 
         [Fact]
+        [Category("PayloadGenerator/LitecoinAddress")]
+        public void litecoin_address_generator_can_generate_address()
+        {
+            var address = "LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54";
+            var amount = .123;
+            var label = "Some Label to Encode";
+            var message = "Some Message to Encode";
+
+            var generator = new PayloadGenerator.LitecoinAddress(address, amount, label, message);
+
+            generator
+                .ToString()
+                .ShouldBe("litecoin:LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54?label=Some%20Label%20to%20Encode&message=Some%20Message%20to%20Encode&amount=.123");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/LitecoinAddress")]
+        public void litecoin_address_generator_should_skip_missing_label()
+        {
+            var address = "LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54";
+            var amount = .123;
+            var message = "Some Message to Encode";
+
+
+            var generator = new PayloadGenerator.LitecoinAddress(address, amount, null, message);
+
+            generator
+                .ToString()
+                .ShouldNotContain("label");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/LitecoinAddress")]
+        public void litecoin_address_generator_should_skip_missing_message()
+        {
+            var address = "LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54";
+            var amount = .123;
+
+
+            var generator = new PayloadGenerator.LitecoinAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldNotContain("message");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/LitecoinAddress")]
+        public void litecoin_address_generator_should_round_to_satoshi()
+        {
+            var address = "LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54";
+            var amount = .123456789;
+
+
+            var generator = new PayloadGenerator.LitecoinAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldContain("amount=.12345679");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/LitecoinAddress")]
+        public void litecoin_address_generator_disregards_current_culture()
+        {
+#if NETCOREAPP1_1
+            var currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("de-DE");
+#else
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+#endif
+
+            var address = "LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54";
+            var amount = .123;
+
+
+            var generator = new PayloadGenerator.LitecoinAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldBe("litecoin:LY1t7iLnwtPCb1DPZP38FA835XzFqXBq54?amount=.123");
+
+#if NETCOREAPP1_1
+            CultureInfo.DefaultThreadCurrentCulture = currentCulture;
+#else
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+#endif
+        }
+
+        [Fact]
         [Category("PayloadGenerator/WiFi")]
         public void wifi_should_build_wep()
         {

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -107,6 +107,96 @@ namespace QRCoderTests
 #endif
         }
 
+        [Fact]
+        [Category("PayloadGenerator/BitcoinCashAddress")]
+        public void bitcoincash_address_generator_can_generate_address()
+        {
+            var address = "qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890";
+            var amount = .123;
+            var label = "Some Label to Encode";
+            var message = "Some Message to Encode";
+
+            var generator = new PayloadGenerator.BitcoinCashAddress(address, amount, label, message);
+
+            generator
+                .ToString()
+                .ShouldBe("bitcoincash:qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890?label=Some%20Label%20to%20Encode&message=Some%20Message%20to%20Encode&amount=.123");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/BitcoinCashAddress")]
+        public void bitcoincash_address_generator_should_skip_missing_label()
+        {
+            var address = "qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890";
+            var amount = .123;
+            var message = "Some Message to Encode";
+
+
+            var generator = new PayloadGenerator.BitcoinCashAddress(address, amount, null, message);
+
+            generator
+                .ToString()
+                .ShouldNotContain("label");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/BitcoinCashAddress")]
+        public void bitcoincash_address_generator_should_skip_missing_message()
+        {
+            var address = "qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890";
+            var amount = .123;
+
+
+            var generator = new PayloadGenerator.BitcoinCashAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldNotContain("message");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/BitcoinCashAddress")]
+        public void bitcoincash_address_generator_should_round_to_satoshi()
+        {
+            var address = "qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890";
+            var amount = .123456789;
+
+
+            var generator = new PayloadGenerator.BitcoinCashAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldContain("amount=.12345679");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/BitcoinCashAddress")]
+        public void bitcoincash_address_generator_disregards_current_culture()
+        {
+#if NETCOREAPP1_1
+            var currentCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("de-DE");
+#else
+            var currentCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+#endif
+
+            var address = "qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890";
+            var amount = .123;
+
+
+            var generator = new PayloadGenerator.BitcoinCashAddress(address, amount);
+
+            generator
+                .ToString()
+                .ShouldBe("bitcoincash:qqtlfk37qyey50f4wfuhc7jw85zsdp8s2swffjk890?amount=.123");
+
+#if NETCOREAPP1_1
+            CultureInfo.DefaultThreadCurrentCulture = currentCulture;
+#else
+            Thread.CurrentThread.CurrentCulture = currentCulture;
+#endif
+        }
 
         [Fact]
         [Category("PayloadGenerator/WiFi")]

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ You can learn more about the payload generator [in our Wiki](https://github.com/
 The PayloadGenerator supports the following types of payloads:
 
 * [BezahlCode](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#31-bezahlcode)
-* [Bitcoin Payment Address](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#32-bitcoin-payment-address)
+* [Bitcoin-Like cryptocurrency (Bitcoin, Bitcoin Cash, Litecoin) payment address](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#32-bitcoin-like-cryptocurrency-payment-address)
 * [Bookmark](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#33-bookmark)
 * [Calendar events (iCal/vEvent)](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#34-calendar-events-icalvevent)
 * [ContactData (MeCard/vCard)](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#35-contactdata-mecardvcard)

--- a/readme.md
+++ b/readme.md
@@ -127,7 +127,7 @@ You can learn more about the payload generator [in our Wiki](https://github.com/
 The PayloadGenerator supports the following types of payloads:
 
 * [BezahlCode](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#31-bezahlcode)
-* [Bitcoin-Like cryptocurrency (Bitcoin, Bitcoin Cash, Litecoin) payment address](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#32-bitcoin-like-cryptocurrency-payment-address)
+* [Bitcoin-Like cryptocurrency (Bitcoin, Bitcoin Cash, Litecoin) payment address](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#32-bitcoin-payment-address)
 * [Bookmark](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#33-bookmark)
 * [Calendar events (iCal/vEvent)](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#34-calendar-events-icalvevent)
 * [ContactData (MeCard/vCard)](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#35-contactdata-mecardvcard)


### PR DESCRIPTION
**Summary**

This pr contains new payload generators for Bitcoin Cash and Litecoin cryptocurrencies.

**Test plan**

I add more tests for this. They similar to Bitcoin payload generator tests.

**Additional information**

If this pr will be approved I also want update this [part](https://github.com/codebude/QRCoder/wiki/Advanced-usage---Payload-generators#32-bitcoin-payment-address) on wiki to add additional examples and update this paragraph.