### PR TITLE
WhatsAppPayload updated with the last click to chat feature and link …

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -331,7 +331,10 @@ namespace QRCoder
             /// <summary>
             /// Let's you compose a WhatApp message and send it the receiver number.
             /// </summary>
-            /// <param name="number">Receiver phone number</param>
+            /// <param name="number">Receiver phone number where the <number> is a full phone number in international format. 
+            /// Omit any zeroes, brackets, or dashes when adding the phone number in international format.
+            /// Use: 1XXXXXXXXXX | Don't use: +001-(XXX)XXXXXXX
+            /// </param>
             /// <param name="message">The message</param>
             public WhatsAppMessage(string number, string message)
             {
@@ -351,7 +354,7 @@ namespace QRCoder
 
             public override string ToString()
             {
-                return ($"whatsapp://send?phone={this.number}&text={Uri.EscapeDataString(message)}");
+                return ($"https://wa.me/{this.number}?text={Uri.EscapeDataString(message)}");
             }
         }
 


### PR DESCRIPTION

**Summary**

This PR fixes/implements the following **bugs/features**:

* [ ] Bug 1: The WhatsApp Payload generates QR but it do not redirect to the WhatsApp App

<!-- You can skip this if you're fixing a typo or other minor things -->

What existing problem does the pull request solve?
1.- The WhatsApp Payload generates QR with link that have the old link structure to send automatically messages, in this pull request i updated the link generation structure and now it generate a QR correctly and when click open WhatsApp to send the message automatically 


