### PR TITLE
Updated build scripts

### DIFF
--- a/.github/workflows/wf-build-release-ci.yml
+++ b/.github/workflows/wf-build-release-ci.yml
@@ -44,15 +44,18 @@ jobs:
       run: dotnet test -c Release -f net35 --nologo --no-build # No coverage for NET3.5 because of bug in combination with Coverlet+Stron naming
     - name: Run test .NET 4.52
       run: dotnet test -c Release -f net452 --nologo --no-build # No coverage for NET4.5 because of bug in combination with Coverlet+Stron naming
-# Skip 1.1 test due to missing support on Github runner
-#    - name: Run test .NET Core 1.1
-#      run: dotnet test -c Release -f netcoreapp1.1 --nologo
+    - name: Run test .NET Core 1.3
+      run: dotnet test -c Release -f netcoreapp1.3 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET Core 2.0
       run: dotnet test -c Release -f netcoreapp2.0 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0
       run: dotnet test -c Release -f net5.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0 Windows
       run: dotnet test -c Release -f net5.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0
+      run: dotnet test -c Release -f net6.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0 Windows
+      run: dotnet test -c Release -f net6.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Codecov update netcoreapp2.0
       uses: codecov/codecov-action@v2
       with:
@@ -71,6 +74,19 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
         flags: net5.0-windows
+    - name: Codecov update net6.0
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./QRCoderTests/coverage.net5.0.opencover.xml
+        flags: net5.0
+    - name: Codecov update net6.0-windows
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
+        flags: net5.0-windows
+
 
   pack-push-ci:
     needs: test
@@ -85,15 +101,23 @@ jobs:
         path: D:\a\qrcoder\qrcoder
     - name: Restore dependencies
       run: dotnet restore
-    - name: Get assembly version
+    - name: Get assembly version QRCoder
       run: echo "ASSEM_VER=$([Reflection.Assembly]::Loadfile( $(-join($pwd,"\QRCoder\bin\Release\net40\QRCoder.dll"))).GetName().version.ToString())"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-    - name: Clean assembly version
+    - name: Clean assembly version QRCoder
       run: echo "ASSEM_VER_SHT=$($env:ASSEM_VER.substring(0, $env:ASSEM_VER.lastIndexOf(".")))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-    - name: Calculate ci suffix
-      run:  echo "CI_TAG=-ci-$([datetime]::now.tostring("yyyyMMddHHmmss"))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-    - name: Build NuGet package      
+    - name: Calculate ci suffix QRCoder
+      run:  echo "CI_TAG=-ci-$([datetime]::now.tostring("yyyyMMddHHmmss"))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append    
+    - name: Get assembly version QRCoder.Xaml
+      run: echo "ASSEM_VER_XAML=$([Reflection.Assembly]::Loadfile( $(-join($pwd,"\QRCoder.Xaml\bin\Release\net40\QRCoder.Xaml.dll"))).GetName().version.ToString())"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - name: Clean assembly version QRCoder.Xaml
+      run: echo "ASSEM_VER_SHT_XAML=$($env:ASSEM_VER_XAML.substring(0, $env:ASSEM_VER_XAML.lastIndexOf(".")))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - name: Calculate ci suffix QRCoder.Xaml
+      run:  echo "CI_TAG_XAML=-ci-$([datetime]::now.tostring("yyyyMMddHHmmss"))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - name: Build QRCoder NuGet package
       run: dotnet pack QRCoder\QRCoder.csproj -c Release --no-build /p:PackageVersion="$env:ASSEM_VER_SHT$env:CI_TAG" /p:PackageReleaseNotes="- This is an automatic CI build ($env:CI_TAG)`n- Please don't use it in productive environments!"
-    - name: Publish to Github packages
+    - name: Build QRCoder.Xaml NuGet package
+      run: dotnet pack QRCoder.Xaml\QRCoder.Xaml.csproj -c Release --no-build /p:PackageVersion="$env:ASSEM_VER_SHT_XAML$env:CI_TAG_XAML" /p:PackageReleaseNotes="- This is an automatic CI build ($env:CI_TAG_XAML)`n- Please don't use it in productive environments!"
+    - name: Publish QRCoder and QRCoder.Xaml to Github packages
       run: dotnet nuget push "**/*.nupkg" --no-symbols --skip-duplicate --api-key $env:GH_PKG_SEC --source https://nuget.pkg.github.com/codebude/index.json
       
     

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -45,15 +45,18 @@ jobs:
       run: dotnet test -c Release -f net35 --nologo --no-build # No coverage for NET3.5 because of bug in combination with Coverlet+Stron naming
     - name: Run test .NET 4.52
       run: dotnet test -c Release -f net452 --nologo --no-build # No coverage for NET4.5 because of bug in combination with Coverlet+Stron naming
-# Skip 1.1 test due to missing support on Github runner
-#    - name: Run test .NET Core 1.1
-#      run: dotnet test -c Release -f netcoreapp1.1 --nologo
+    - name: Run test .NET Core 1.3
+      run: dotnet test -c Release -f netcoreapp1.3 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET Core 2.0
       run: dotnet test -c Release -f netcoreapp2.0 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0
       run: dotnet test -c Release -f net5.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0 Windows
       run: dotnet test -c Release -f net5.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0
+      run: dotnet test -c Release -f net6.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0 Windows
+      run: dotnet test -c Release -f net6.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Codecov update netcoreapp2.0
       uses: codecov/codecov-action@v2
       with:
@@ -67,6 +70,18 @@ jobs:
         files: ./QRCoderTests/coverage.net5.0.opencover.xml
         flags: net5.0
     - name: Codecov update net5.0-windows
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
+        flags: net5.0-windows
+    - name: Codecov update net6.0
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./QRCoderTests/coverage.net5.0.opencover.xml
+        flags: net5.0
+    - name: Codecov update net6.0-windows
       uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -86,13 +101,19 @@ jobs:
         path: D:\a\qrcoder\qrcoder
     - name: Restore dependencies
       run: dotnet restore
-    - name: Get assembly version
+    - name: Get assembly version QRCoder
       run: echo "ASSEM_VER=$([Reflection.Assembly]::Loadfile( $(-join($pwd,"\QRCoder\bin\Release\net40\QRCoder.dll"))).GetName().version.ToString())"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-    - name: Clean assembly version
-      run: echo "ASSEM_VER_SHT=$($env:ASSEM_VER.substring(0, $env:ASSEM_VER.lastIndexOf(".")))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
-    - name: Build NuGet package
+    - name: Clean assembly version QRCoder
+      run: echo "ASSEM_VER_SHT=$($env:ASSEM_VER.substring(0, $env:ASSEM_VER.lastIndexOf(".")))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append   
+    - name: Get assembly version QRCoder.Xaml
+      run: echo "ASSEM_VER_XAML=$([Reflection.Assembly]::Loadfile( $(-join($pwd,"\QRCoder.Xaml\bin\Release\net40\QRCoder.Xaml.dll"))).GetName().version.ToString())"  | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - name: Clean assembly version QRCoder.Xaml
+      run: echo "ASSEM_VER_SHT_XAML=$($env:ASSEM_VER_XAML.substring(0, $env:ASSEM_VER_XAML.lastIndexOf(".")))" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
+    - name: Build QRCoder NuGet package
       run: dotnet pack QRCoder\QRCoder.csproj -c Release --no-build /p:PackageVersion="$env:ASSEM_VER_SHT" /p:PackageReleaseNotes="${{ github.event.inputs.releaseNotes }}"   
-    - name: Publish to Github packages
+    - name: Build QRCoder.Xaml NuGet package
+      run: dotnet pack QRCoder.Xaml\QRCoder.Xaml.csproj -c Release --no-build /p:PackageVersion="$env:ASSEM_VER_SHT_XAML" /p:PackageReleaseNotes="${{ github.event.inputs.releaseNotes }}"   
+    - name: Publish QRCoder and QRCoder.Xaml to Github packages
       run: dotnet nuget push "**/*.nupkg" --no-symbols --skip-duplicate --api-key $env:GH_PKG_SEC --source https://nuget.pkg.github.com/codebude/index.json
       
     

--- a/.github/workflows/wf-build-test.yml
+++ b/.github/workflows/wf-build-test.yml
@@ -44,15 +44,18 @@ jobs:
       run: dotnet test -c Release -f net35 --nologo --no-build # No coverage for NET3.5 because of bug in combination with Coverlet+Stron naming
     - name: Run test .NET 4.52
       run: dotnet test -c Release -f net452 --nologo --no-build # No coverage for NET4.5 because of bug in combination with Coverlet+Stron naming
-# Skip 1.1 test due to missing support on Github runner
-#    - name: Run test .NET Core 1.1
-#      run: dotnet test -c Release -f netcoreapp1.1 --nologo
+    - name: Run test .NET Core 1.3
+      run: dotnet test -c Release -f netcoreapp1.3 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET Core 2.0
       run: dotnet test -c Release -f netcoreapp2.0 --nologo /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0
       run: dotnet test -c Release -f net5.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     - name: Run test .NET 5.0 Windows
       run: dotnet test -c Release -f net5.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0
+      run: dotnet test -c Release -f net6.0 --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
+    - name: Run test .NET 6.0 Windows
+      run: dotnet test -c Release -f net6.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
     
   clean:
     needs: [build, test]


### PR DESCRIPTION
Updated build scripts In preparation for the XamlQRCode carve-out. Scripts should be updated first, so that build and test runs, when XamlQRCode is decoupled from QRCoder.

This PR fixes/implements the following **bugs/features**:

* [X] Adds support for QRCoder.Xaml project/package

