### PR TITLE
Ensure that an OTP's issuer and label values are escaped correctly

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -2028,11 +2028,11 @@ namespace QRCoder
                     throw new Exception("Label must not have a ':'");
                 }
 
-                if (Label != null && Issuer != null)
+                if (Label != null && escapedIssuer != null)
                 {
                     label = escapedIssuer + ":" + Label;
                 }
-                else if (Issuer != null)
+                else if (escapedIssuer != null)
                 {
                     label = escapedIssuer;
                 }

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -2030,11 +2030,11 @@ namespace QRCoder
 
                 if (Label != null && Issuer != null)
                 {
-                    label = Issuer + ":" + Label;                    
+                    label = escapedIssuer + ":" + Label;
                 }
                 else if (Issuer != null)
                 {
-                    label = Issuer;
+                    label = escapedIssuer;
                 }
 
                 if (label != null)

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -2012,6 +2012,7 @@ namespace QRCoder
                 }
                 string strippedSecret = Secret.Replace(" ", "");
                 string escapedIssuer = null;
+                string escapedLabel = null;
                 string label = null;
 
                 if (!String40Methods.IsNullOrWhiteSpace(Issuer))
@@ -2023,14 +2024,18 @@ namespace QRCoder
                     escapedIssuer = Uri.EscapeDataString(Issuer);
                 }
 
-                if (!String40Methods.IsNullOrWhiteSpace(Label) && Label.Contains(":"))
+                if (!String40Methods.IsNullOrWhiteSpace(Label))
                 {
-                    throw new Exception("Label must not have a ':'");
+                    if (Label.Contains(":"))
+                    {
+                        throw new Exception("Label must not have a ':'");
+                    }
+                    escapedLabel = Uri.EscapeDataString(Label);
                 }
 
-                if (Label != null && escapedIssuer != null)
+                if (escapedLabel != null && escapedIssuer != null)
                 {
-                    label = escapedIssuer + ":" + Label;
+                    label = escapedIssuer + ":" + escapedLabel;
                 }
                 else if (escapedIssuer != null)
                 {

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -2662,6 +2662,21 @@ namespace QRCoderTests
 
         [Fact]
         [Category("PayloadGenerator/OneTimePassword")]
+        public void one_time_password_generator_time_based_generates_with_standard_options_escapes_issuer()
+        {
+            var pg = new PayloadGenerator.OneTimePassword
+            {
+                Secret = "pwq6 5q55",
+                Issuer = "Google Google",
+                Label = "test@google.com",
+            };
+
+            pg.ToString().ShouldBe("otpauth://totp/Google%20Google:test@google.com?secret=pwq65q55&issuer=Google%20Google");
+        }
+
+
+        [Fact]
+        [Category("PayloadGenerator/OneTimePassword")]
         public void one_time_password_generator_hmac_based_generates_with_standard_options()
         {
             var pg = new PayloadGenerator.OneTimePassword
@@ -2674,6 +2689,22 @@ namespace QRCoderTests
             };
 
             pg.ToString().ShouldBe("otpauth://hotp/Google:test@google.com?secret=pwq65q55&issuer=Google&counter=500");
+        }
+
+        [Fact]
+        [Category("PayloadGenerator/OneTimePassword")]
+        public void one_time_password_generator_hmac_based_generates_with_standard_options_escapes_issuer()
+        {
+            var pg = new PayloadGenerator.OneTimePassword
+            {
+                Secret = "pwq6 5q55",
+                Issuer = "Google Google",
+                Label = "test@google.com",
+                Type = PayloadGenerator.OneTimePassword.OneTimePasswordAuthType.HOTP,
+                Counter = 500,
+            };
+
+            pg.ToString().ShouldBe("otpauth://hotp/Google%20Google:test@google.com?secret=pwq65q55&issuer=Google%20Google&counter=500");
         }
 
 

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -2656,22 +2656,22 @@ namespace QRCoderTests
                 Label = "test@google.com",
             };
 
-            pg.ToString().ShouldBe("otpauth://totp/Google:test@google.com?secret=pwq65q55&issuer=Google");
+            pg.ToString().ShouldBe("otpauth://totp/Google:test%40google.com?secret=pwq65q55&issuer=Google");
         }
 
 
         [Fact]
         [Category("PayloadGenerator/OneTimePassword")]
-        public void one_time_password_generator_time_based_generates_with_standard_options_escapes_issuer()
+        public void one_time_password_generator_time_based_generates_with_standard_options_escapes_issuer_and_label()
         {
             var pg = new PayloadGenerator.OneTimePassword
             {
                 Secret = "pwq6 5q55",
                 Issuer = "Google Google",
-                Label = "test@google.com",
+                Label = "test/test@google.com",
             };
 
-            pg.ToString().ShouldBe("otpauth://totp/Google%20Google:test@google.com?secret=pwq65q55&issuer=Google%20Google");
+            pg.ToString().ShouldBe("otpauth://totp/Google%20Google:test%2Ftest%40google.com?secret=pwq65q55&issuer=Google%20Google");
         }
 
 
@@ -2688,23 +2688,23 @@ namespace QRCoderTests
                 Counter = 500,
             };
 
-            pg.ToString().ShouldBe("otpauth://hotp/Google:test@google.com?secret=pwq65q55&issuer=Google&counter=500");
+            pg.ToString().ShouldBe("otpauth://hotp/Google:test%40google.com?secret=pwq65q55&issuer=Google&counter=500");
         }
 
         [Fact]
         [Category("PayloadGenerator/OneTimePassword")]
-        public void one_time_password_generator_hmac_based_generates_with_standard_options_escapes_issuer()
+        public void one_time_password_generator_hmac_based_generates_with_standard_options_escapes_issuer_and_label()
         {
             var pg = new PayloadGenerator.OneTimePassword
             {
                 Secret = "pwq6 5q55",
                 Issuer = "Google Google",
-                Label = "test@google.com",
+                Label = "test/test@google.com",
                 Type = PayloadGenerator.OneTimePassword.OneTimePasswordAuthType.HOTP,
                 Counter = 500,
             };
 
-            pg.ToString().ShouldBe("otpauth://hotp/Google%20Google:test@google.com?secret=pwq65q55&issuer=Google%20Google&counter=500");
+            pg.ToString().ShouldBe("otpauth://hotp/Google%20Google:test%2Ftest%40google.com?secret=pwq65q55&issuer=Google%20Google&counter=500");
         }
 
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.-->


## Summary
<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [x] Creating an OTP with an issuer/label that contains a space or other restricted characters does not properly escape the issuer/label

<!-- You can skip this if you're fixing a typo or other minor things -->
### What existing problem does the pull request solve?**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Currently, if you create an OTP with an issuer that contains a space, for example:

```cs
var oneTimePassword = new OneTimePassword {
	Issuer = "Google Google",
	Label = "test@google.com",
	Secret = "pwq6 5q55"
};
```

and then call `ToString` on that `oneTimePassword`, that will return:

`otpauth://totp/Google Google:test@google.com?secret=pwq65q55&issuer=Google%20Google`

(note the first "Google Google" is not escaped, like the second one in the `issuer` parameter)

which then looks like this in Google Authenticator after scanning the resulting QR code:

![File](https://user-images.githubusercontent.com/712727/157164366-b759c14f-6e1f-4709-982b-f7055d610520.jpg)

This PR resolves this issue by correctly escaping both instances of the issuer in the URL, which then appears correctly in Google Authenticator:

`otpauth://totp/Google%20Google:test@google.com?secret=pwq65q55&issuer=Google%20Google`

## Test plan
<!-- Demonstrate that your code is solid. If possible add a short test case/test steps. -->

Test cases have been added.

## Closing issues
<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
N/A