### PR TITLE
Bugfixing # 399

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -1139,7 +1139,8 @@ namespace QRCoder
                 //AddInf "logical" element
                 SwissQrCodePayload += (!string.IsNullOrEmpty(additionalInformation.UnstructureMessage) ? additionalInformation.UnstructureMessage : string.Empty) + br; //Ustrd
                 SwissQrCodePayload += additionalInformation.Trailer + br; //Trailer
-                SwissQrCodePayload += (!string.IsNullOrEmpty(additionalInformation.BillInformation) ? additionalInformation.BillInformation : string.Empty) + br; //StrdBkgInf
+		// Bug #399 If BillInformation is empty, insert no linebreak
+                SwissQrCodePayload += (!string.IsNullOrEmpty(additionalInformation.BillInformation) ? additionalInformation.BillInformation + br : string.Empty); //StrdBkgInf
 
                 //AltPmtInf "logical" element
                 if (!string.IsNullOrEmpty(alternativeProcedure1))


### PR DESCRIPTION
Bug #399 If BillInformation is empty, insert no linebreak

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.-->


## Summary
<!-- Summarize your pull request in a couple of words -->

This PR fixes/implements the following **bugs/features**:

* [x] Bug #399


<!-- You can skip this if you're fixing a typo or other minor things -->
### What existing problem does the pull request solve?**
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
See description from bug #399 

## Test plan
<!-- Demonstrate that your code is solid. If possible add a short test case/test steps. -->
Create SwissQRCode with:

- Trailer "EPD"
- UnstrucureMessage "Text"
- BillInformation [empty or null]

Result --> if you scan the qrCode after "EPD" does not exist a line break! ;-)

## Closing issues
<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #399 and #398
