### PR TITLE
Allow SVG exporting under .NET 6 on Linux

### DIFF
--- a/QRCoder/SvgQRCode.cs
+++ b/QRCoder/SvgQRCode.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0_OR_GREATER
 using QRCoder.Extensions;
 using System;
 using System.Collections;
@@ -11,9 +11,6 @@ using static QRCoder.SvgQRCode;
 
 namespace QRCoder
 {
-#if NET6_0_WINDOWS
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-#endif
     public class SvgQRCode : AbstractQRCode, IDisposable
     {
         /// <summary>
@@ -270,13 +267,16 @@ namespace QRCoder
             private object _logoRaw;
             private bool _isEmbedded;
 
-
+#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
             /// <summary>
             /// Create a logo object to be used in SvgQRCode renderer
             /// </summary>
             /// <param name="iconRasterized">Logo to be rendered as Bitmap/rasterized graphic</param>
             /// <param name="iconSizePercent">Degree of percentage coverage of the QR code by the logo</param>
             /// <param name="fillLogoBackground">If true, the background behind the logo will be cleaned</param>
+#if NET6_0_WINDOWS
+            [System.Runtime.Versioning.SupportedOSPlatform("windows")]
+#endif
             public SvgLogo(Bitmap iconRasterized, int iconSizePercent = 15, bool fillLogoBackground = true)
             {
                 _iconSizePercent = iconSizePercent;
@@ -293,6 +293,7 @@ namespace QRCoder
                 _logoRaw = iconRasterized;
                 _isEmbedded = false;
             }
+#endif
 
             /// <summary>
             /// Create a logo object to be used in SvgQRCode renderer
@@ -379,9 +380,6 @@ namespace QRCoder
         }
     }
 
-#if NET6_0_WINDOWS
-    [System.Runtime.Versioning.SupportedOSPlatform("windows")]
-#endif
     public static class SvgQRCodeHelper
     {
         public static string GetQRCode(string plainText, int pixelsPerModule, string darkColorHex, string lightColorHex, ECCLevel eccLevel, bool forceUtf8 = false, bool utf8BOM = false, EciMode eciMode = EciMode.Default, int requestedVersion = -1, bool drawQuietZones = true, SizingMode sizingMode = SizingMode.WidthHeightAttribute, SvgLogo logo = null)

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -103,7 +103,7 @@ namespace QRCoderTests
             result.ShouldBe("4ab0417cc6127e347ca1b2322c49ed7d");
         }
 
-#if !NET6_0
+#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
         public void can_render_svg_qrcode_with_png_logo()

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NET6_0
+﻿#if !NETCOREAPP1_1
 using System;
 using Xunit;
 using QRCoder;
@@ -103,6 +103,7 @@ namespace QRCoderTests
             result.ShouldBe("4ab0417cc6127e347ca1b2322c49ed7d");
         }
 
+#if !NET6_0
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
         public void can_render_svg_qrcode_with_png_logo()
@@ -121,6 +122,7 @@ namespace QRCoderTests
             var result = HelperFunctions.StringToHash(svg);
             result.ShouldBe("78e02e8ba415f15817d5ed88c4afca31");            
         }
+#endif
 
         [Fact]
         [Category("QRRenderer/SvgQRCode")]


### PR DESCRIPTION
## Summary

This PR allows SVGs to be created under .NET 6 on Linux.  The majority of the code is already compatible and does not use System.Drawing.  The only code that does is the constructor for SvgLogo.  This implementation simply removes only that constructor on .NET 6 on Linux, without removing any other code, allowing:
1. SVGs without an embedded logo may be created
2. The alternate SvgLogo constructor may be used, for SVG-based logos

This does not allow users to use PNG-based logos on .NET 6+ on Linux -- a 3rd constructor could be added for that scenario, either public or protected, where the user would supply the PNG data (generated from a third-party image library, for example).  This is solved by #491 which can be merged independently.

### What existing problem does the pull request solve?

This allows users of QRCoder on Linux to export SVG files

### What is unique about this proposal?

Does not introduce any new dependencies

## Test plan

The currently existing tests within the codebase have been updated to run on .NET 6 on Linux, excluding the one for the constructor that references `System.Drawing.Bitmap`.