### PR TITLE
Support passing PNG data directly to SvgLogo

### DIFF
--- a/QRCoder/SvgQRCode.cs
+++ b/QRCoder/SvgQRCode.cs
@@ -285,7 +285,7 @@ namespace QRCoder
                     using (var bitmap = new Bitmap(iconRasterized))
                     {
                         bitmap.Save(ms, System.Drawing.Imaging.ImageFormat.Png);
-                        _logoData = Convert.ToBase64String(ms.GetBuffer(), Base64FormattingOptions.None); 
+                        _logoData = Convert.ToBase64String(ms.GetBuffer(), 0, (int)ms.Length, Base64FormattingOptions.None); 
                     }
                 }
                 _mediaType = MediaType.PNG;
@@ -309,6 +309,22 @@ namespace QRCoder
                 _fillLogoBackground = fillLogoBackground;
                 _logoRaw = iconVectorized;
                 _isEmbedded = iconEmbedded;
+            }
+
+            /// <summary>
+            /// Create a logo object to be used in SvgQRCode renderer
+            /// </summary>
+            /// <param name="iconRasterized">Logo to be rendered as PNG</param>
+            /// <param name="iconSizePercent">Degree of percentage coverage of the QR code by the logo</param>
+            /// <param name="fillLogoBackground">If true, the background behind the logo will be cleaned</param>
+            public SvgLogo(byte[] iconRasterized, int iconSizePercent = 15, bool fillLogoBackground = true)
+            {
+                _iconSizePercent = iconSizePercent;
+                _logoData = Convert.ToBase64String(iconRasterized, Base64FormattingOptions.None);
+                _mediaType = MediaType.PNG;
+                _fillLogoBackground = fillLogoBackground;
+                _logoRaw = iconRasterized;
+                _isEmbedded = false;
             }
 
             /// <summary>

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -105,7 +105,7 @@ namespace QRCoderTests
 
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
-        public void can_render_svg_qrcode_with_png_logo()
+        public void can_render_svg_qrcode_with_png_logo_bitmap()
         {
             //Create QR code
             var gen = new QRCodeGenerator();
@@ -119,7 +119,26 @@ namespace QRCoderTests
             var svg = new SvgQRCode(data).GetGraphic(10, Color.DarkGray, Color.White, logo: logoObj);
 
             var result = HelperFunctions.StringToHash(svg);
-            result.ShouldBe("78e02e8ba415f15817d5ed88c4afca31");            
+            result.ShouldBe("7d53f25af04e52b20550deb2e3589e96");
+        }
+
+        [Fact]
+        [Category("QRRenderer/SvgQRCode")]
+        public void can_render_svg_qrcode_with_png_logo_bytearray()
+        {
+            //Create QR code
+            var gen = new QRCodeGenerator();
+            var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.H);
+
+            //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
+            var logoBitmap = System.IO.File.ReadAllBytes(GetAssemblyPath() + "\\assets\\noun_software engineer_2909346.png");
+            var logoObj = new SvgQRCode.SvgLogo(iconRasterized: logoBitmap, 15);
+            logoObj.GetMediaType().ShouldBe<SvgQRCode.SvgLogo.MediaType>(SvgQRCode.SvgLogo.MediaType.PNG);
+
+            var svg = new SvgQRCode(data).GetGraphic(10, Color.DarkGray, Color.White, logo: logoObj);
+
+            var result = HelperFunctions.StringToHash(svg);
+            result.ShouldBe("7d53f25af04e52b20550deb2e3589e96");
         }
 
         [Fact]

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -120,8 +120,9 @@ namespace QRCoderTests
             var svg = new SvgQRCode(data).GetGraphic(10, Color.DarkGray, Color.White, logo: logoObj);
 
             var result = HelperFunctions.StringToHash(svg);
-            result.ShouldBe("7d53f25af04e52b20550deb2e3589e96");
+            result.ShouldBe("78e02e8ba415f15817d5ed88c4afca31");
         }
+#endif
 
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
@@ -141,7 +142,6 @@ namespace QRCoderTests
             var result = HelperFunctions.StringToHash(svg);
             result.ShouldBe("7d53f25af04e52b20550deb2e3589e96");
         }
-#endif
 
         [Fact]
         [Category("QRRenderer/SvgQRCode")]


### PR DESCRIPTION
## Summary

This PR fixes/implements the following bugs and features:

* Fixes a bug where extra null bytes are included with the logo embedded within a SVG
* Adds a constructor allowing for a custom PNG file data to be supplied to the logo embedded within a SVG

### What existing problem does the pull request solve?

When using a third-party library to encode image data, or when reading PNG directly from a stream, this additional constructor allows for it to be passed directly to the created SVG file, without passing through the System.Drawing library.

## Test plan

Tests have been added to the codebase
