### PR TITLE
Added support for UTC and DateTimeOffsets in VEVENT generator

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -1883,6 +1883,20 @@ namespace QRCoder
             /// <param name="subject">Subject/title of the calender event</param>
             /// <param name="description">Description of the event</param>
             /// <param name="location">Location (lat:long or address) of the event</param>
+            /// <param name="start">Start time (incl. UTC offset) of the event</param>
+            /// <param name="end">End time (incl. UTC offset) of the event</param>
+            /// <param name="allDayEvent">Is it a full day event?</param>
+            /// <param name="encoding">Type of encoding (universal or iCal)</param>
+            public CalendarEvent(string subject, string description, string location, DateTimeOffset start, DateTimeOffset end, bool allDayEvent, EventEncoding encoding = EventEncoding.Universal) : this(subject, description, location, DateTime.SpecifyKind(start.ToUniversalTime().DateTime, DateTimeKind.Utc), DateTime.SpecifyKind(end.ToUniversalTime().DateTime, DateTimeKind.Utc), allDayEvent, encoding)
+            {
+            }
+
+            /// <summary>
+            /// Generates a calender entry/event payload.
+            /// </summary>
+            /// <param name="subject">Subject/title of the calender event</param>
+            /// <param name="description">Description of the event</param>
+            /// <param name="location">Location (lat:long or address) of the event</param>
             /// <param name="start">Start time of the event</param>
             /// <param name="end">End time of the event</param>
             /// <param name="allDayEvent">Is it a full day event?</param>
@@ -1893,9 +1907,17 @@ namespace QRCoder
                 this.description = description;
                 this.location = location;
                 this.encoding = encoding;
-                string dtFormat = allDayEvent ? "yyyyMMdd" : "yyyyMMddTHHmmss";
-                this.start = start.ToString(dtFormat);
-                this.end = end.ToString(dtFormat);
+                string dtFormatStart = "yyyyMMdd", dtFormatEnd = "yyyyMMdd";
+                if (!allDayEvent)
+                {
+                    dtFormatStart = dtFormatEnd = "yyyyMMddTHHmmss";
+                    if (start.Kind == DateTimeKind.Utc)
+                        dtFormatStart = "yyyyMMddTHHmmssZ";
+                    if (end.Kind == DateTimeKind.Utc)
+                        dtFormatEnd = "yyyyMMddTHHmmssZ";
+                }                
+                this.start = start.ToString(dtFormatStart);
+                this.end = end.ToString(dtFormatEnd);
             }
 
             public override string ToString()

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -1887,7 +1887,7 @@ namespace QRCoder
             /// <param name="end">End time (incl. UTC offset) of the event</param>
             /// <param name="allDayEvent">Is it a full day event?</param>
             /// <param name="encoding">Type of encoding (universal or iCal)</param>
-            public CalendarEvent(string subject, string description, string location, DateTimeOffset start, DateTimeOffset end, bool allDayEvent, EventEncoding encoding = EventEncoding.Universal) : this(subject, description, location, DateTime.SpecifyKind(start.ToUniversalTime().DateTime, DateTimeKind.Utc), DateTime.SpecifyKind(end.ToUniversalTime().DateTime, DateTimeKind.Utc), allDayEvent, encoding)
+            public CalendarEvent(string subject, string description, string location, DateTimeOffset start, DateTimeOffset end, bool allDayEvent, EventEncoding encoding = EventEncoding.Universal) : this(subject, description, location, start.UtcDateTime, end.UtcDateTime, allDayEvent, encoding)
             {
             }
 

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -816,7 +816,7 @@ namespace QRCoderTests
             var location = "Programmer's paradise, Beachtown, Paradise";
             var alldayEvent = false;
             var begin = new DateTime(2016, 01, 03, 12, 00, 00);
-            var end = new DateTime(2016, 01, 03, 14, 30, 0);
+            var end = new DateTime(2016, 01, 03, 14, 30, 00);
             var encoding = PayloadGenerator.CalendarEvent.EventEncoding.Universal;
 
             var generator = new PayloadGenerator.CalendarEvent(subject, description, location, begin, end, alldayEvent, encoding);
@@ -840,6 +840,42 @@ namespace QRCoderTests
             var generator = new PayloadGenerator.CalendarEvent(subject, description, location, begin, end, alldayEvent, encoding);
 
             generator.ToString().ShouldBe($"BEGIN:VCALENDAR{Environment.NewLine}VERSION:2.0{Environment.NewLine}BEGIN:VEVENT{Environment.NewLine}SUMMARY:Release party{Environment.NewLine}DESCRIPTION:A small party for the new QRCoder. Bring some beer!{Environment.NewLine}LOCATION:Programmer's paradise, Beachtown, Paradise{Environment.NewLine}DTSTART:20160103T120000{Environment.NewLine}DTEND:20160103T143000{Environment.NewLine}END:VEVENT{Environment.NewLine}END:VCALENDAR");
+        }
+
+
+        [Fact]
+        [Category("PayloadGenerator/CalendarEvent")]
+        public void calendarevent_should_build_with_utc_datetime()
+        {
+            var subject = "Release party";
+            var description = "A small party for the new QRCoder. Bring some beer!";
+            var location = "Programmer's paradise, Beachtown, Paradise";
+            var alldayEvent = false;
+            var begin = new DateTime(2016, 01, 03, 12, 00, 00, DateTimeKind.Utc);
+            var end = new DateTime(2016, 01, 03, 14, 30, 00, DateTimeKind.Utc);
+            var encoding = PayloadGenerator.CalendarEvent.EventEncoding.Universal;
+
+            var generator = new PayloadGenerator.CalendarEvent(subject, description, location, begin, end, alldayEvent, encoding);
+
+            generator.ToString().ShouldBe($"BEGIN:VEVENT{Environment.NewLine}SUMMARY:Release party{Environment.NewLine}DESCRIPTION:A small party for the new QRCoder. Bring some beer!{Environment.NewLine}LOCATION:Programmer's paradise, Beachtown, Paradise{Environment.NewLine}DTSTART:20160103T120000Z{Environment.NewLine}DTEND:20160103T143000Z{Environment.NewLine}END:VEVENT");
+        }
+
+
+        [Fact]
+        [Category("PayloadGenerator/CalendarEvent")]
+        public void calendarevent_should_build_with_utc_offset()
+        {
+            var subject = "Release party";
+            var description = "A small party for the new QRCoder. Bring some beer!";
+            var location = "Programmer's paradise, Beachtown, Paradise";
+            var alldayEvent = false;
+            var begin = new DateTimeOffset(2016, 01, 03, 12, 00, 00, new TimeSpan(3, 0, 0));
+            var end = new DateTimeOffset(2016, 01, 03, 14, 30, 00, new TimeSpan(3, 0, 0));
+            var encoding = PayloadGenerator.CalendarEvent.EventEncoding.Universal;
+
+            var generator = new PayloadGenerator.CalendarEvent(subject, description, location, begin, end, alldayEvent, encoding);
+
+            generator.ToString().ShouldBe($"BEGIN:VEVENT{Environment.NewLine}SUMMARY:Release party{Environment.NewLine}DESCRIPTION:A small party for the new QRCoder. Bring some beer!{Environment.NewLine}LOCATION:Programmer's paradise, Beachtown, Paradise{Environment.NewLine}DTSTART:20160103T090000Z{Environment.NewLine}DTEND:20160103T113000Z{Environment.NewLine}END:VEVENT");
         }
 
 


### PR DESCRIPTION
## Summary
Inspired by issue #458 and the discussion there, this PR extends the CalendarEvent payload generator with a UTC DateTime functionality.

This PR fixes the following **problems**:

* [X] CalendarEvent took DateTime objects for start and end of event, but didn't care about DateTime.Kind or any offset

### Details
- If plain DateTime objects (with DateTime.Kind.Unspecified) are passed to the payload generator nothing change, to avoid breaking changes
- If DateTime objects with DateTime.Kind.Utc are handed over, the payload generator will respect the UTC and save the dates as "UTC" in the iCal calendar event
- Another constructor overload is added that accepts DateTimeOffset instead of DateTime objects. Those will be converted to DateTime objects with Kind.Utc internally by use of the offset defined in the DateTimeOffset objects.

## Test plan
Test cases were added to the PayloadGeneratorTests.cs

## Closing issues
Fixes #458
