### PR TITLE
a couple places where ArtQRCode creates a short lived Bitmap but neve…

### DIFF
--- a/QRCoder/ArtQRCode.cs
+++ b/QRCoder/ArtQRCode.cs
@@ -83,17 +83,21 @@ public class ArtQRCode : AbstractQRCode, IDisposable
             if (backgroundImage != null)
             {
                 if (backgroundImageStyle == BackgroundImageStyle.Fill)
-                    graphics.DrawImage(Resize(backgroundImage, size), 0, 0);
+                {
+                    using var resizedBg = Resize(backgroundImage, size);
+                    graphics.DrawImage(resizedBg, 0, 0);
+                }
                 else if (backgroundImageStyle == BackgroundImageStyle.DataAreaOnly)
                 {
                     var bgOffset = 4 - offset;
-                    graphics.DrawImage(Resize(backgroundImage, size - (2 * bgOffset * pixelsPerModule)), 0 + (bgOffset * pixelsPerModule), (bgOffset * pixelsPerModule));
+                    using var resizedBg = Resize(backgroundImage, size - (2 * bgOffset * pixelsPerModule));
+                    graphics.DrawImage(resizedBg, 0 + (bgOffset * pixelsPerModule), (bgOffset * pixelsPerModule));
                 }
             }
 
 
-            var darkModulePixel = MakeDotPixel(pixelsPerModule, pixelSize, darkBrush);
-            var lightModulePixel = MakeDotPixel(pixelsPerModule, pixelSize, lightBrush);
+            using var darkModulePixel = MakeDotPixel(pixelsPerModule, pixelSize, darkBrush);
+            using var lightModulePixel = MakeDotPixel(pixelsPerModule, pixelSize, lightBrush);
 
             for (var x = 0; x < numModules; x += 1)
             {
@@ -137,7 +141,7 @@ public class ArtQRCode : AbstractQRCode, IDisposable
     private static Bitmap MakeDotPixel(int pixelsPerModule, int pixelSize, SolidBrush brush)
     {
         // draw a dot
-        var bitmap = new Bitmap(pixelSize, pixelSize);
+        using var bitmap = new Bitmap(pixelSize, pixelSize);
         using (var graphics = Graphics.FromImage(bitmap))
         {
             graphics.FillEllipse(brush, new Rectangle(0, 0, pixelSize, pixelSize));
@@ -212,7 +216,7 @@ public class ArtQRCode : AbstractQRCode, IDisposable
         var offsetX = (newSize - scaledWidth) / 2;
         var offsetY = (newSize - scaledHeight) / 2;
 
-        var scaledImage = new Bitmap(image, new Size(scaledWidth, scaledHeight));
+        using var scaledImage = new Bitmap(image, new Size(scaledWidth, scaledHeight));
 
         var bm = new Bitmap(newSize, newSize);
 


### PR DESCRIPTION
…r disposes of it and orphans the GDI+ handle, leading to handle exhaustion in some cases.

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.

A similar PR may already be submitted!
Please search among the Pull request before creating one: https://github.com/codebude/QRCoder/pulls?utf8=%E2%9C%93&q=

For more information, see the `CONTRIBUTING` guide.-->


## Summary
<!-- Summarize your pull request in a couple of words -->

wraps internal throw away bitmaps in using blocks so that they are disposed of.

This PR fixes/implements the following **bugs/features**:

* [x] BUG GDI+ handle leakages

<!-- You can skip this if you're fixing a typo or other minor things -->
### What existing problem does the pull request solve?
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->
when i recursively generate ArtQRCode(s) i get handle exhaustion errors which show themselves as "A generic error occurred in GDI+."
## Test plan
<!-- Demonstrate that your code is solid. If possible add a short test case/test steps. -->
Passes project unit tests. Simple using blocks added to internal objects only, so it should not change how anything works.

## Closing issues
<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
didn't create an issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource management during QR code generation to ensure temporary graphics objects used for rendering are properly disposed, enhancing application stability and preventing potential memory-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->